### PR TITLE
Update cluster templates page navigation + tweaks

### DIFF
--- a/src/components/ClusterTemplateDetails/ClusterTemplateDetailsPage.tsx
+++ b/src/components/ClusterTemplateDetails/ClusterTemplateDetailsPage.tsx
@@ -15,11 +15,7 @@ import { useHistory } from 'react-router-dom';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useClusterTemplate } from '../../hooks/useClusterTemplates';
 import ClusterTemplateDetailsSections from './ClusterTemplateDetailsSections';
-import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 import PageLoader from '../../helpers/PageLoader';
-
-export const getResourceListPageUrl = (resourceGVK: K8sGroupVersionKind) =>
-  `/k8s/cluster/${resourceGVK.group}~${resourceGVK.version}~${resourceGVK.kind}`;
 
 const PageBreadcrumb: React.FC<{ clusterTemplateName: string }> = ({
   clusterTemplateName,

--- a/src/components/ClusterTemplatesPage/ClusterTemplatesPage.tsx
+++ b/src/components/ClusterTemplatesPage/ClusterTemplatesPage.tsx
@@ -1,12 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import * as React from 'react';
 import {
-  HorizontalNav,
   ListPageCreateDropdown,
   ListPageHeader,
-  NavPage,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { Switch, useHistory } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
+import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import ClusterTemplatesTab from './ClusterTemplatesTab';
 import HelmRepositoriesTab from './HelmRepositoriesTab';
 import { useClusterTemplatesCount } from '../../hooks/useClusterTemplates';
@@ -14,30 +13,26 @@ import { useHelmRepositoriesCount } from '../../hooks/useHelmRepositories';
 import { clusterTemplateGVK } from '../../constants';
 import { useTranslation } from '../../hooks/useTranslation';
 import { getNavLabelWithCount } from '../../utils/utils';
+import { getReference } from '../../utils/k8s';
 
-const clusterTemplateReference = `${clusterTemplateGVK.group}~${clusterTemplateGVK.version}~${clusterTemplateGVK.kind}`;
+const clusterTemplateReference = getReference(clusterTemplateGVK);
+
+const useActiveTab = () => {
+  const { search } = useLocation();
+  const activeTab = React.useMemo(() => {
+    const query = new URLSearchParams(search);
+    return query.get('tab') === 'repositories' ? 'repositories' : 'templates';
+  }, [search]);
+  return activeTab;
+};
 
 const ClusterTemplatesPage = () => {
   const { t } = useTranslation();
   const history = useHistory();
   const templatesCount = useClusterTemplatesCount();
   const helmRepositoriesCount = useHelmRepositoriesCount();
+  const activeTab = useActiveTab();
 
-  const pages: NavPage[] = React.useMemo(
-    () => [
-      {
-        href: '',
-        name: getNavLabelWithCount('Templates', templatesCount),
-        component: ClusterTemplatesTab,
-      },
-      {
-        href: 'repositories',
-        name: getNavLabelWithCount('HELM repositories', helmRepositoriesCount),
-        component: HelmRepositoriesTab,
-      },
-    ],
-    [templatesCount, helmRepositoriesCount],
-  );
   const actionItems = React.useMemo(
     () => ({
       NEW_CLUSTER_TEMPLATE: t('Cluster template'),
@@ -45,6 +40,21 @@ const ClusterTemplatesPage = () => {
     }),
     [t],
   );
+
+  const handleTabSelect: React.ComponentProps<typeof Tabs>['onSelect'] = (
+    _,
+    eventKey,
+  ) => {
+    switch (eventKey) {
+      case 'repositories':
+        history.push(
+          `/k8s/cluster/${clusterTemplateReference}?tab=repositories`,
+        );
+        break;
+      default:
+        history.push(`/k8s/cluster/${clusterTemplateReference}`);
+    }
+  };
 
   const handleCreateDropdownActionClick = (item: string) => {
     switch (item) {
@@ -58,21 +68,53 @@ const ClusterTemplatesPage = () => {
   };
 
   return (
-    <Switch>
-      <>
-        <ListPageHeader title="Cluster templates">
-          <ListPageCreateDropdown
-            createAccessReview={{ groupVersionKind: clusterTemplateReference }}
-            items={actionItems}
-            onClick={handleCreateDropdownActionClick}
-          >
-            {t('Create')}
-          </ListPageCreateDropdown>
-        </ListPageHeader>
-
-        <HorizontalNav pages={pages} />
-      </>
-    </Switch>
+    <>
+      <ListPageHeader title="Cluster templates">
+        <ListPageCreateDropdown
+          createAccessReview={{ groupVersionKind: clusterTemplateReference }}
+          items={actionItems}
+          onClick={handleCreateDropdownActionClick}
+        >
+          {t('Create')}
+        </ListPageCreateDropdown>
+      </ListPageHeader>
+      <div className="co-m-page__body">
+        <Tabs
+          activeKey={activeTab}
+          onSelect={handleTabSelect}
+          aria-label="Cluster templates page tabs"
+          role="resource-list-tabs"
+          usePageInsets
+        >
+          <Tab
+            eventKey="templates"
+            title={
+              <TabTitleText>
+                {getNavLabelWithCount('Templates', templatesCount)}
+              </TabTitleText>
+            }
+            aria-label="Cluster templates tab"
+          />
+          <Tab
+            eventKey="repositories"
+            title={
+              <TabTitleText>
+                {getNavLabelWithCount(
+                  'HELM repositories',
+                  helmRepositoriesCount,
+                )}
+              </TabTitleText>
+            }
+            aria-label="HELM repositories tab"
+          />
+        </Tabs>
+        {activeTab === 'repositories' ? (
+          <HelmRepositoriesTab />
+        ) : (
+          <ClusterTemplatesTab />
+        )}
+      </div>
+    </>
   );
 };
 

--- a/src/helpers/PageLoader.tsx
+++ b/src/helpers/PageLoader.tsx
@@ -13,18 +13,15 @@ import {
   Spinner,
   Title,
 } from '@patternfly/react-core';
-import ErrorState from './ErrorState';
+import ErrorState, { ErrorStateProps } from './ErrorState';
 
 type PageLoaderProps = {
   children: React.ReactNode;
   loaded?: boolean;
   error?: unknown;
-  errorId?: string;
-  errorTitle?: string;
-  errorMessage?: string;
-};
+} & Omit<ErrorStateProps, 'error'>;
 
-export function ErrorPage(props: { error: Error; actions?: React.ReactNode }) {
+export function ErrorPage(props: ErrorStateProps) {
   return (
     <Page>
       <PageSection>
@@ -69,21 +66,12 @@ export function LoadingPage(props: {
 
 const PageLoader = ({
   loaded = false,
-  error,
-  errorId,
-  errorTitle,
-  errorMessage,
   children,
+  error,
+  ...restErrorStateProps
 }: PageLoaderProps) => {
   if (error) {
-    return (
-      <ErrorState
-        error={error}
-        errorId={errorId}
-        errorTitle={errorTitle}
-        errorMessage={errorMessage}
-      />
-    );
+    return <ErrorPage error={error} {...restErrorStateProps} />;
   }
   if (!loaded) {
     return <LoadingPage />;

--- a/src/helpers/TableLoader.tsx
+++ b/src/helpers/TableLoader.tsx
@@ -1,24 +1,19 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import * as React from 'react';
 import { Skeleton } from '@patternfly/react-core';
-import ErrorState from './ErrorState';
+import ErrorState, { ErrorStateProps } from './ErrorState';
 
 type TableLoaderProps = {
   children: React.ReactNode;
   loaded?: boolean;
   error?: unknown;
-  errorId?: string;
-  errorTitle?: string;
-  errorMessage?: string;
-};
+} & Omit<ErrorStateProps, 'error'>;
 
 function TableLoader({
   loaded = false,
-  error,
-  errorId,
-  errorTitle,
-  errorMessage,
   children,
+  error,
+  ...restErrorStateProps
 }: TableLoaderProps) {
   if (!loaded) {
     return (
@@ -38,14 +33,7 @@ function TableLoader({
     );
   }
   if (error) {
-    return (
-      <ErrorState
-        error={error}
-        errorId={errorId}
-        errorTitle={errorTitle}
-        errorMessage={errorMessage}
-      ></ErrorState>
-    );
+    return <ErrorState error={error} {...restErrorStateProps} />;
   }
   return <>{children}</>;
 }

--- a/src/utils/k8s.ts
+++ b/src/utils/k8s.ts
@@ -1,0 +1,21 @@
+import {
+  K8sGroupVersionKind,
+  K8sResourceKindReference,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+/**
+ * @deprecated - This will become obsolete when we move away from K8sResourceKindReference to K8sGroupVersionKind
+ * Provides a reference string that uniquely identifies the group, version, and kind of a k8s resource.
+ * @param K8sGroupVersionKind Pass K8sGroupVersionKind which will have group, version, and kind of a k8s resource.
+ * @param K8sGroupVersionKind.group Pass group of k8s resource or model.
+ * @param K8sGroupVersionKind.version Pass version of k8s resource or model.
+ * @param K8sGroupVersionKind.kind Pass kind of k8s resource or model.
+ * @returns The reference for any k8s resource i.e `group~version~kind`.
+ * If the group will not be present then "core" will be returned as part of the group in reference.
+ */
+export const getReference = ({
+  group,
+  version,
+  kind,
+}: K8sGroupVersionKind): K8sResourceKindReference =>
+  [group || 'core', version, kind].join('~');


### PR DESCRIPTION
* Using redirect to `/~tabs` route to handle cluster templates page tabs collided with a resource detail route, resulting in first the detail page with error to get displayed and then getting replaced with actual cluster templates page. This change fixes it by using query params to manage active tab state.
* Use custom tabs implementation instead of HorizontalNav which does not work with query params
* Tweak TableLoader, PageLoader and ErrorState components
* Remove unused `/~tabs` plugin route