### PR TITLE
Updates to Helm chart repoository edit modal

### DIFF
--- a/src/components/HelmRepositories/EditHelmRepositoryDialog.tsx
+++ b/src/components/HelmRepositories/EditHelmRepositoryDialog.tsx
@@ -1,5 +1,5 @@
-/* Copyright Contributors to the Open Cluster Management project */
 import * as React from 'react';
+import * as Yup from 'yup';
 import {
   Modal,
   ModalVariant,
@@ -12,9 +12,6 @@ import {
   Alert,
   AlertVariant,
 } from '@patternfly/react-core';
-import * as Yup from 'yup';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-
 import { ConfigMap, HelmChartRepository, Secret } from '../../types';
 import {
   k8sCreate,
@@ -27,7 +24,7 @@ import { configMapGVK, helmRepoGVK, secretGVK } from '../../constants';
 import TableLoader from '../../helpers/TableLoader';
 import { InputField, CheckboxField, TextAreaField } from 'formik-pf';
 import SelectField from '../../helpers/SelectField';
-import { Formik } from 'formik';
+import { Formik, FormikProps } from 'formik';
 import { TFunction } from 'react-i18next';
 import { useTranslation } from '../../hooks/useTranslation';
 import { getErrorMessage } from '../../utils/utils';
@@ -45,6 +42,11 @@ export type EditHelmRepoCredsValues = {
 type EditHelmRepositoryDialogProps = {
   helmChartRepository: HelmChartRepository;
   closeDialog: () => void;
+};
+
+type FormError = {
+  title: string;
+  message: string;
 };
 
 const SECRET_TYPE = 'kubernetes.io/tls';
@@ -146,9 +148,7 @@ const EditHelmRepositoryDialog = ({
       [helmChartRepositoryReference]: helmChartRepoModel,
     },
   ] = useK8sModels();
-  const [formError, setFormError] = React.useState<
-    { title: string; message: string } | undefined
-  >();
+  const [formError, setFormError] = React.useState<FormError | undefined>();
   const { ca, tlsClientConfig } = helmChartRepository.spec.connectionConfig;
   const {
     secrets: { data: secrets, loaded: secretsLoaded },
@@ -195,11 +195,9 @@ const EditHelmRepositoryDialog = ({
       getDefaultSecretName(helmChartRepository.metadata?.name);
 
     const configMapToUpdate = configMaps.find(
-      (cm) => cm.metadata?.name === existingConfigMapName,
+      (cm) => cm.metadata?.name === configMapName,
     );
-    const secretToUpdate = secrets.find(
-      (s) => s.metadata?.name === existingSecretName,
-    );
+    const secretToUpdate = secrets.find((s) => s.metadata?.name === secretName);
 
     setFormError(undefined);
 
@@ -352,141 +350,172 @@ const EditHelmRepositoryDialog = ({
           )}
           onSubmit={handleSubmit}
           validationSchema={getValidationSchema(t)}
-        >
-          {({
-            handleSubmit,
-            values,
-            isSubmitting,
-            isValid,
-            errors,
-            setFieldValue,
-            setFieldTouched,
-          }) => {
-            const setTlsConfigValues = async (
-              value: EditHelmRepoCredsValues['existingSecretName'],
-            ) => {
-              const { tlsClientCert, tlsClientKey } = getDecodedSecretData(
-                availableTlsSecrets.find(
-                  (secret) => secret.metadata?.name === value,
-                )?.data,
-              );
-              await setFieldValue('tlsClientCert', tlsClientCert || '', true);
-              await setFieldTouched('tlsClientCert', true);
-              await setFieldValue('tlsClientKey', tlsClientKey || '', true);
-              await setFieldTouched('tlsClientKey', true);
-            };
-            const setCaCertificateValue = async (
-              value: EditHelmRepoCredsValues['existingConfigMapName'],
-            ) => {
-              await setFieldValue(
-                'caCertificate',
-                configMaps.find((cm) => cm.metadata?.name === value)?.data?.[
-                  'ca-bundle.crt'
-                ] || '',
-                true,
-              );
-              await setFieldTouched('caCertificate', true);
-            };
-            return (
-              <>
-                <ModalBoxBody>
-                  <Form id="edit-helm-repo-form" onSubmit={handleSubmit}>
-                    <InputField
-                      fieldId="url"
-                      name="url"
-                      label={t('HELM chart repository URL')}
-                      type={TextInputTypes.text}
-                      placeholder="Repository URL"
-                      isRequired
-                    />
-                    <CheckboxField
-                      fieldId="useCredentials"
-                      name="useCredentials"
-                      label={t('Requires authentication')}
-                      helperText={t(
-                        'Add credentials and custom certificate authority (CA) certificates to connect to private helm chart repository.',
-                      )}
-                    />
-                    {values.useCredentials && (
-                      <>
-                        <SelectField
-                          name="existingConfigMapName"
-                          fieldId="existingConfigMapName"
-                          label={t('CA certificate ConfigMap')}
-                          placeholder={t('Select a ConfigMap')}
-                          onChange={(value) =>
-                            setCaCertificateValue(value.toString())
-                          }
-                          options={configMaps.map((cm) => ({
-                            value: cm.metadata?.name || '',
-                            disabled: false,
-                          }))}
-                        />
-                        <TextAreaField
-                          fieldId="caCertificate"
-                          name="caCertificate"
-                          label={t('CA certificate')}
-                          helperTextInvalid={errors.tlsClientKey}
-                          isRequired
-                        />
-                        <SelectField
-                          name="existingSecretName"
-                          fieldId="existingSecretName"
-                          label={t('TLS config Credential')}
-                          placeholder={t('Select a credential')}
-                          onChange={(value) =>
-                            setTlsConfigValues(value.toString())
-                          }
-                          options={availableTlsSecrets.map((secret) => ({
-                            value: secret.metadata?.name || '',
-                            disabled: false,
-                          }))}
-                        />
-                        <TextAreaField
-                          fieldId="tlsClientCert"
-                          name="tlsClientCert"
-                          label={t('TLS client certificate')}
-                          helperTextInvalid={errors.tlsClientCert}
-                          isRequired
-                        />
-                        <TextAreaField
-                          fieldId="tlsClientKey"
-                          name="tlsClientKey"
-                          label={t('TLS client key')}
-                          helperTextInvalid={errors.tlsClientKey}
-                          isRequired
-                        />
-                      </>
-                    )}
-                    {formError && (
-                      <Alert
-                        variant={AlertVariant.danger}
-                        title={formError?.title}
-                        isInline
-                      >
-                        {formError?.message}
-                      </Alert>
-                    )}
-                  </Form>
-                </ModalBoxBody>
-                <ModalBoxFooter>
-                  <Button
-                    onClick={() => handleSubmit()}
-                    variant={ButtonVariant.primary}
-                    isDisabled={isSubmitting || !isValid}
-                  >
-                    {t('Submit')}
-                  </Button>
-                  <Button onClick={closeDialog} variant={ButtonVariant.link}>
-                    {t('Cancel')}
-                  </Button>
-                </ModalBoxFooter>
-              </>
-            );
-          }}
-        </Formik>
+          component={(props) => (
+            <FormikContent
+              {...props}
+              availableTlsSecrets={availableTlsSecrets}
+              configMaps={configMaps}
+              formError={formError}
+              closeDialog={closeDialog}
+            />
+          )}
+        />
       </TableLoader>
     </Modal>
+  );
+};
+
+type FormikContentProps = FormikProps<EditHelmRepoCredsValues> & {
+  availableTlsSecrets: Secret[];
+  configMaps: ConfigMap[];
+  closeDialog: EditHelmRepositoryDialogProps['closeDialog'];
+  formError?: FormError;
+};
+
+const FormikContent = ({
+  handleSubmit,
+  values,
+  isSubmitting,
+  isValid,
+  errors,
+  setFieldValue,
+  setFieldTouched,
+  availableTlsSecrets,
+  configMaps,
+  formError,
+  closeDialog,
+}: FormikContentProps) => {
+  const { t } = useTranslation();
+  const isInitialRenderRef = React.useRef(true);
+
+  React.useEffect(() => {
+    if (!isInitialRenderRef.current)
+      setCaCertificateValue(values.existingConfigMapName);
+  }, [values.existingConfigMapName]);
+
+  React.useEffect(() => {
+    if (!isInitialRenderRef.current)
+      setTlsConfigValues(values.existingSecretName);
+  }, [values.existingSecretName]);
+
+  React.useEffect(() => {
+    isInitialRenderRef.current = false;
+  }, []);
+
+  const setTlsConfigValues = async (
+    value: EditHelmRepoCredsValues['existingSecretName'],
+  ) => {
+    const { tlsClientCert, tlsClientKey } = getDecodedSecretData(
+      availableTlsSecrets.find((secret) => secret.metadata?.name === value)
+        ?.data,
+    );
+    await setFieldValue('tlsClientCert', tlsClientCert || '', true);
+    setFieldTouched('tlsClientCert', true, false);
+    await setFieldValue('tlsClientKey', tlsClientKey || '', true);
+    setFieldTouched('tlsClientKey', true, false);
+  };
+
+  const setCaCertificateValue = async (
+    value: EditHelmRepoCredsValues['existingConfigMapName'],
+  ) => {
+    await setFieldValue(
+      'caCertificate',
+      configMaps.find((cm) => cm.metadata?.name === value)?.data?.[
+        'ca-bundle.crt'
+      ] || '',
+      true,
+    );
+    setFieldTouched('caCertificate', true, false);
+  };
+  return (
+    <>
+      <ModalBoxBody>
+        <Form id="edit-helm-repo-form" onSubmit={handleSubmit}>
+          <InputField
+            fieldId="url"
+            name="url"
+            label={t('HELM chart repository URL')}
+            type={TextInputTypes.text}
+            placeholder="Repository URL"
+            isRequired
+          />
+          <CheckboxField
+            fieldId="useCredentials"
+            name="useCredentials"
+            label={t('Requires authentication')}
+            helperText={t(
+              'Add credentials and custom certificate authority (CA) certificates to connect to private helm chart repository.',
+            )}
+          />
+          {values.useCredentials && (
+            <>
+              <SelectField
+                name="existingConfigMapName"
+                fieldId="existingConfigMapName"
+                label={t('CA certificate ConfigMap')}
+                placeholder={t('Select a ConfigMap')}
+                options={configMaps.map((cm) => ({
+                  value: cm.metadata?.name || '',
+                  disabled: false,
+                }))}
+              />
+              <TextAreaField
+                fieldId="caCertificate"
+                name="caCertificate"
+                label={t('CA certificate')}
+                helperTextInvalid={errors.tlsClientKey}
+                isRequired
+              />
+              <SelectField
+                name="existingSecretName"
+                fieldId="existingSecretName"
+                label={t('TLS config Credential')}
+                placeholder={t('Select a credential')}
+                options={availableTlsSecrets.map((secret) => ({
+                  value: secret.metadata?.name || '',
+                  disabled: false,
+                }))}
+              />
+              <TextAreaField
+                fieldId="tlsClientCert"
+                name="tlsClientCert"
+                label={t('TLS client certificate')}
+                helperTextInvalid={errors.tlsClientCert}
+                isRequired
+              />
+              <TextAreaField
+                fieldId="tlsClientKey"
+                name="tlsClientKey"
+                label={t('TLS client key')}
+                helperTextInvalid={errors.tlsClientKey}
+                isRequired
+              />
+            </>
+          )}
+          {formError && (
+            <Alert
+              variant={AlertVariant.danger}
+              title={formError?.title}
+              isInline
+            >
+              {formError?.message}
+            </Alert>
+          )}
+        </Form>
+      </ModalBoxBody>
+      <ModalBoxFooter>
+        <Button
+          onClick={() => handleSubmit()}
+          variant={ButtonVariant.primary}
+          isDisabled={isSubmitting || !isValid}
+        >
+          {t('Submit')}
+        </Button>
+        <Button onClick={closeDialog} variant={ButtonVariant.link}>
+          {t('Cancel')}
+        </Button>
+      </ModalBoxFooter>
+    </>
   );
 };
 

--- a/src/helpers/SelectField.tsx
+++ b/src/helpers/SelectField.tsx
@@ -1,4 +1,3 @@
-/* Copyright Contributors to the Open Cluster Management project */
 import * as React from 'react';
 import {
   FormGroup,
@@ -6,10 +5,9 @@ import {
   SelectVariant,
   SelectOption,
   SelectProps,
-  SelectOptionObject,
+  FormGroupProps,
 } from '@patternfly/react-core';
 import { useField } from 'formik';
-import { FormGroupProps } from '@patternfly/react-core';
 
 // https://github.com/patternfly-labs/formik-pf/blob/main/src/components/types.ts
 export type FieldProps = {
@@ -28,7 +26,6 @@ type SelectFieldProps = FieldProps & {
   placeholderText?: React.ReactNode;
   isCreatable?: boolean;
   hasOnCreateOption?: boolean;
-  onChange?: (value: string | SelectOptionObject) => void;
 };
 
 // https://github.com/patternfly-labs/formik-pf/blob/main/src/components/utils.ts
@@ -39,7 +36,6 @@ const SelectField: React.FC<SelectFieldProps> = ({
   name,
   label,
   options,
-  onChange,
   placeholderText,
   helperText,
   isRequired,
@@ -57,14 +53,12 @@ const SelectField: React.FC<SelectFieldProps> = ({
 
   const onSelect: SelectProps['onSelect'] = (_, value) => {
     setValue(value as string);
-    onChange && onChange(value);
     setTouched(true);
     setIsOpen(false);
   };
 
   const onClearSelection = () => {
     setValue('');
-    onChange && onChange('');
     setTouched(true);
   };
 


### PR DESCRIPTION
* Fix updating of default credentials secret and configMap when no existing secret/configMap is selected
* Handle updating helm repository credentials on selecting existing secret/configMap using useEffect instead of custom onChange prop on SelectField