### PR TITLE
Use ArgoCD secrets instead of HELM repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .devcontainer/dev.env
 .vscode
+ocp-console/

--- a/README.md
+++ b/README.md
@@ -99,6 +99,24 @@ OC_PASS=<password>
 3. `yarn run start`
 4. Navigate to <http://localhost:9000/example>
 
+### Running and updating the cluster as a service operator
+
+#### Install/update the operator
+
+1. Install `operator-sdk` (<https://sdk.operatorframework.io/docs/installation/>)
+2. `oc login` to the development cluster
+3. `oc project cluster-aas-operator`
+4. `operator-sdk run bundle quay.io/stolostron/cluster-templates-bundle:2.7.0-125bb4a8e82d8bce3e66ff4f083cf63e24292bbf --timeout 5m` (Use desired version from <https://quay.io/repository/stolostron/cluster-templates-bundle?tab=tags>)
+5. Once the operator bundle is installed, there is a service called `cluster-aas-operator-repo-bridge-service` in the `cluster-aas-operator` namespace
+
+#### Setup proxy to the bridge service
+
+To allow the development UI connecting to the bridge service via proxy, the service needs to be exposed via a route:
+
+`oc process -f scripts/start-ocp-console/ocp-console-oauth-client.yaml | oc apply -f -`
+
+Available endpoints are defined here: <https://github.com/stolostron/cluster-templates-operator/blob/main/bridge/server.go#L175-L176>
+
 ## Docker image
 
 Before you can deploy your plugin on a cluster, you must build an image and

--- a/scripts/start-ocp-console/ocp-bridge-service-route.yaml
+++ b/scripts/start-ocp-console/ocp-bridge-service-route.yaml
@@ -1,0 +1,23 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: cluster-aas-operator-repo-bridge-service-route
+  namespace: cluster-aas-operator
+  labels:
+    caas-repo-bridge: 'true'
+    operators.coreos.com/cluster-aas-operator.cluster-aas-operator: ''
+  annotations:
+    openshift.io/host.generated: 'true'
+spec:
+  host: >-
+    claas-helm-repo-cluster-aas-operator.apps.rawagner3.cyty.p1.openshiftapps.com
+  to:
+    kind: Service
+    name: cluster-aas-operator-repo-bridge-service
+    weight: 100
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None

--- a/scripts/start-ocp-console/ocp-console-oauth-client.yaml
+++ b/scripts/start-ocp-console/ocp-console-oauth-client.yaml
@@ -1,0 +1,20 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: console-oauth-client
+parameters:
+  - name: OAUTH_SECRET
+    generate: expression
+    from: "[a-zA-Z0-9]{40}"
+  - name: REDIRECT_URL
+    value: http://localhost:9000/auth/callback
+    required: true
+objects:
+  - apiVersion: oauth.openshift.io/v1
+    kind: OAuthClient
+    metadata:
+      name: console-oauth-client
+    grantMethod: auto
+    secret: ${OAUTH_SECRET}
+    redirectURIs:
+    - ${REDIRECT_URL}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const TEMPLATES_HELM_REPO_LABEL = 'clustertemplates.openshift.io/helm-rep
 export const clusterTemplateVersion = 'v1alpha1';
 export const clusterTemplateGroup = 'clustertemplate.openshift.io';
 export const INSTANCE_NAMESPACE_VAR = '${instance_ns}';
+export const ARGOCD_NAMESPACE = 'argocd';
 
 export const helmRepoGVK: K8sGroupVersionKind = {
   kind: 'HelmChartRepository',

--- a/src/hooks/useArgoCDRepositories.ts
+++ b/src/hooks/useArgoCDRepositories.ts
@@ -1,0 +1,94 @@
+import { load } from 'js-yaml';
+import * as React from 'react';
+import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
+import { HelmRepoIndex } from '../types';
+
+const REPOSITORIES_ENDPOINT =
+  '/api/proxy/plugin/clustertemplates-plugin/repositories/api/helm-repositories';
+const REPOSITORY_ENDPOINT =
+  '/api/proxy/plugin/clustertemplates-plugin/repositories/api/helm-repository';
+
+const getRepositoryEndpoint = (name) => `${REPOSITORY_ENDPOINT}/${name}`;
+
+export type ArgoCDRepositoryListResult = [HelmRepoIndex | undefined, boolean, unknown];
+
+export const useArgoCDRepositories = (): ArgoCDRepositoryListResult => {
+  const [repoList, setRepoList] = React.useState<HelmRepoIndex>();
+  const [repoListLoaded, setRepoListLoaded] = React.useState(false);
+  const [error, setError] = React.useState<unknown>();
+
+  React.useEffect(() => {
+    const fetch = async () => {
+      try {
+        const res = await consoleFetch(REPOSITORIES_ENDPOINT);
+        console.log('res', res);
+        const yaml = await res.text();
+        console.log('yaml', yaml);
+        setRepoList(load(yaml) as HelmRepoIndex);
+      } catch (e) {
+        setError(e);
+      } finally {
+        setRepoListLoaded(true);
+      }
+    };
+    fetch();
+  }, []);
+
+  return [repoList, repoListLoaded, error];
+};
+
+export type ArgoCDRepositoryResult = [HelmRepoIndex | undefined, boolean, unknown];
+
+export const useArgoCDRepository = (repositoryName: string): ArgoCDRepositoryResult => {
+  const [repository, setRepository] = React.useState<HelmRepoIndex>();
+  const [repositoryLoaded, setRepositoryLoaded] = React.useState(false);
+  const [error, setError] = React.useState<unknown>();
+
+  React.useEffect(() => {
+    const fetch = async () => {
+      try {
+        const res = await consoleFetch(getRepositoryEndpoint(repositoryName));
+        console.log('res', res);
+        const yaml = await res.text();
+        console.log('yaml', yaml);
+        setRepository(load(yaml) as HelmRepoIndex);
+      } catch (e) {
+        setError(e);
+      } finally {
+        setRepositoryLoaded(true);
+      }
+    };
+    fetch();
+  }, []);
+
+  return [repository, repositoryLoaded, error];
+};
+
+export const getRepoCharts = (index: HelmRepoIndex | undefined, repoName: string) =>
+  Object.keys(index?.entries || {})
+    .filter((k) => {
+      const keyParts = k.split('--');
+      return keyParts[keyParts.length - 1] === repoName;
+    })
+    .reduce((acc, k) => {
+      return [...acc, ...(index?.entries?.[k] || [])];
+    }, [] as { name: string; version: string; created: string }[]);
+
+export type HelmRepositoryChartsMap = {
+  [chartName: string]: string[];
+};
+
+export const getRepoChartsMap = (
+  index: HelmRepoIndex | undefined,
+  repoName: string,
+): HelmRepositoryChartsMap => {
+  const map: HelmRepositoryChartsMap = {};
+  const repoCharts = getRepoCharts(index, repoName);
+  for (const chart of repoCharts) {
+    if (!(chart.name in map)) {
+      map[chart.name] = [];
+    }
+    map[chart.name].push(chart.version);
+  }
+  return map;
+};

--- a/src/hooks/useArgoCDSecrets.ts
+++ b/src/hooks/useArgoCDSecrets.ts
@@ -1,0 +1,37 @@
+import { useK8sWatchResource, WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
+import * as React from 'react';
+import { ARGOCD_NAMESPACE, secretGVK } from '../constants';
+import { ArgoCDSecretData, Secret } from '../types';
+import { getDecodedSecretData } from '../utils/secrets';
+
+const initResource = {
+  groupVersionKind: secretGVK,
+  isList: true,
+  namespace: ARGOCD_NAMESPACE,
+  selector: { matchLabels: { 'argocd.argoproj.io/secret-type': 'repository' } },
+};
+
+export const useArgoCDSecrets = (): WatchK8sResult<Secret[]> => {
+  const [secrets, loaded, loadError] = useK8sWatchResource<Secret[]>(initResource);
+
+  const decodedSecrets = secrets.map((secret) => ({
+    ...secret,
+    data: getDecodedSecretData<ArgoCDSecretData>(secret.data),
+  }));
+  const helmTypeSecrets = decodedSecrets.filter((secret) => secret.data.type === 'helm');
+  return [helmTypeSecrets, loaded, loadError];
+};
+
+export const useArgoCDSecretsCount = () => {
+  const [secrets, loaded, loadError] = useK8sWatchResource<Secret[]>(initResource);
+  return loaded && !loadError ? secrets.length : undefined;
+};
+
+export const useArgoCDSecretByRepoUrl = (repoUrl: string): [Secret, boolean, unknown] => {
+  const [secrets, loaded, loadError] = useArgoCDSecrets();
+  const secret = React.useMemo(
+    () => secrets.find((secret) => secret.data.url === repoUrl),
+    [secrets],
+  );
+  return [secret, loaded, loadError];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,18 @@ export type Secret = K8sResourceCommon & {
   type?: string;
 };
 
+export type ArgoCDSecretData = {
+  name?: string;
+  url?: string;
+  description?: string;
+  username?: string;
+  password?: string;
+  project?: string;
+  tlsClientCertData?: string;
+  tlsClientCertKey?: string;
+  type?: 'helm' | 'git';
+};
+
 export type ConfigMap = {
   data?: { [key: string]: string };
 } & K8sResourceCommon;

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,0 +1,14 @@
+import { Secret } from '../types';
+
+export function getDecodedSecretData<T extends Record<string, unknown>>(
+  secretData: Secret['data'] = {},
+) {
+  const decodedSecretData = Object.entries(secretData).reduce<T>(
+    (res, [key, value]) => ({
+      ...res,
+      [key]: Buffer.from(value, 'base64').toString('ascii'),
+    }),
+    {} as T,
+  );
+  return decodedSecretData;
+}

--- a/start-console.sh
+++ b/start-console.sh
@@ -2,14 +2,25 @@
 
 set -euo pipefail
 
+mkdir -p ocp-console
+oc process -f scripts/start-ocp-console/ocp-console-oauth-client.yaml | oc apply -f -
+oc get oauthclient console-oauth-client -o jsonpath='{.secret}' > ocp-console/console-client-secret
+oc get secrets -n default --field-selector type=kubernetes.io/service-account-token -o json | \
+    jq '.items[0].data."ca.crt"' -r | python -m base64 -d > ocp-console/ca.crt
+
 CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}
 CONSOLE_PORT=${CONSOLE_PORT:=9000}
 
 echo "Starting local OpenShift console..."
 
-BRIDGE_USER_AUTH="disabled"
+BRIDGE_BASE_ADDRESS="http://localhost:9000"
+BRIDGE_USER_AUTH="openshift"
 BRIDGE_K8S_MODE="off-cluster"
-BRIDGE_K8S_AUTH="bearer-token"
+BRIDGE_K8S_AUTH="openshift"
+BRIDGE_CA_FILE="/tmp/ca.crt"
+BRIDGE_USER_AUTH_OIDC_CLIENT_ID="console-oauth-client"
+BRIDGE_USER_AUTH_OIDC_CLIENT_SECRET_FILE="/tmp/console-client-secret"
+BRIDGE_USER_AUTH_OIDC_CA_FILE="/tmp/ca.crt"
 BRIDGE_K8S_MODE_OFF_CLUSTER_SKIP_VERIFY_TLS=true
 BRIDGE_K8S_MODE_OFF_CLUSTER_ENDPOINT=$(oc whoami --show-server)
 # The monitoring operator is not always installed (e.g. for local OpenShift). Tolerate missing config maps.
@@ -37,12 +48,30 @@ if [ -x "$(command -v podman)" ]; then
     if [ "$(uname -s)" = "Linux" ]; then
         # Use host networking on Linux since host.containers.internal is unreachable in some environments.
         BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://localhost:9001"
-        podman run --pull always --rm --network=host --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+        podman run \
+          --pull always --rm --network=host \
+          -v $PWD/ocp-console/console-client-secret:/tmp/console-client-secret:Z \
+          -v $PWD/ocp-console/ca.crt:/tmp/ca.crt:Z \
+          --env BRIDGE_PLUGIN_PROXY='{"services":[{"consoleAPIPath":"/api/proxy/plugin/clustertemplates-plugin/repositories/","endpoint":"https://claas-helm-repo-cluster-aas-operator.apps.rawagner3.cyty.p1.openshiftapps.com","authorize": true}]}' \
+          --env-file <(set | grep BRIDGE) \
+          $CONSOLE_IMAGE
     else
         BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.containers.internal:9001"
-        podman run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+        podman run \
+          --pull always --rm -p "$CONSOLE_PORT":9000 \
+          -v $PWD/ocp-console/console-client-secret:/tmp/console-client-secret \
+          -v $PWD/ocp-console/ca.crt:/tmp/ca.crt \
+          --env BRIDGE_PLUGIN_PROXY='{"services":[{"consoleAPIPath":"/api/proxy/plugin/clustertemplates-plugin/repositories/","endpoint":"https://claas-helm-repo-cluster-aas-operator.apps.rawagner3.cyty.p1.openshiftapps.com","authorize": true}]}' \
+          --env-file <(set | grep BRIDGE) \
+          $CONSOLE_IMAGE
     fi
 else
     BRIDGE_PLUGINS="${npm_package_consolePlugin_name}=http://host.docker.internal:9001"
-    docker run --pull always --rm -p "$CONSOLE_PORT":9000 --env-file <(set | grep BRIDGE) $CONSOLE_IMAGE
+    docker run \
+      --pull always --rm -p "$CONSOLE_PORT":9000 \
+      -v $PWD/ocp-console/console-client-secret:/tmp/console-client-secret \
+      -v $PWD/ocp-console/ca.crt:/tmp/ca.crt \
+      --env BRIDGE_PLUGIN_PROXY='{"services":[{"consoleAPIPath":"/api/proxy/plugin/clustertemplates-plugin/repositories/","endpoint":"https://claas-helm-repo-cluster-aas-operator.apps.rawagner3.cyty.p1.openshiftapps.com","authorize": true}]}' \
+      --env-file <(set | grep BRIDGE) \
+      $CONSOLE_IMAGE
 fi


### PR DESCRIPTION
- Move ocp console resource yamls inside scripts/start-ocp-console
- Add hooks for listing repository/ies from operator service
- Enhance start-console.sh script to use authenticated setup and configure bridge plugin proxy
- utilities for decoding Secret data
- update README with guidelines for updating the operator and making the bridge proxy service endpoints accessible